### PR TITLE
Add config parameters to retry failed chunks during upload

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto eol=lf
+*.php text eol=lf
+*.json text eol=lf
+*.md text eol=lf

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The FCS SDK for PHP enables PHP developers to build solutions with Firebrand Clo
 With the FCS SDK for PHP, developers can get started in minutes by using [Composer](http://getcomposer.org).
 
 This new version is built on top of [Guzzle](http://guzzlephp.org), a PHP HTTP client
-framework, which provides increased performance.  The FCS SDK for PHP requires PHP 5.3.2.
+framework, which provides increased performance.  The FCS SDK for PHP requires PHP 5.4.
 
 ## Before Using the SDK
 

--- a/composer.json
+++ b/composer.json
@@ -10,18 +10,18 @@
     ],
     "require": {
         "php": ">=5.4",
-        "guzzlehttp/guzzle": "^7.4",
         "ext-curl": "*",
         "ext-dom": "*",
-      "ext-json": "*"
+        "ext-json": "*",
+        "guzzlehttp/guzzle": "^7.4"
+    },
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "^2.16",
+        "phpstan/phpstan": "^0.12.2"
     },
     "autoload": {
         "psr-0": {
             "Fcs": "src/"
         }
-    },
-    "require-dev": {
-        "phpstan/phpstan": "^0.12.2",
-        "friendsofphp/php-cs-fixer": "^2.16"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "php": ">=5.4",
         "guzzlehttp/guzzle": "^7.4",
         "ext-curl": "*",
-        "ext-dom": "*"
+        "ext-dom": "*",
+      "ext-json": "*"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2",
+        "php": ">=5.4",
         "guzzlehttp/guzzle": "^7.4"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,9 @@
     ],
     "require": {
         "php": ">=5.4",
-        "guzzlehttp/guzzle": "^7.4"
+        "guzzlehttp/guzzle": "^7.4",
+        "ext-curl": "*",
+        "ext-dom": "*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Fcs/Fcs.php
+++ b/src/Fcs/Fcs.php
@@ -579,8 +579,8 @@ class Fcs
             $isLastChunk = ($chunk == ($chunks - 1));
             $chunkSize = $isLastChunk ? $lastChunkSize : $this->_chunkSize;
             $chunkQuery = "name=$fileName&chunk=$chunk&chunks=$chunks";
-            self::debug("Sending Chunk isLastChunk=$isLastChunk, lastChunkSize=$lastChunkSize, chunkSize=$chunkSize, chunk=$chunk, chunks=$chunks, uploadAttemptsRemaining=" . $this->_uploadAttemptsRemaining);
             while ($this->_uploadAttemptsRemaining > 0) {
+                self::debug("Sending Chunk isLastChunk=$isLastChunk, lastChunkSize=$lastChunkSize, chunkSize=$chunkSize, chunk=$chunk, chunks=$chunks, uploadAttemptsRemaining=" . $this->_uploadAttemptsRemaining);
                 try {
                     $this->sendChunk($uri, $chunkQuery, $path, $contentType, $bytesSent, $chunkSize);
                     $bytesSent += $chunkSize;

--- a/src/Fcs/Fcs.php
+++ b/src/Fcs/Fcs.php
@@ -251,7 +251,7 @@ class Fcs
         $accessSecret = self::getArrayValue($config, 'secret');
         $chunkSize = self::getArrayValue($config, 'chunkSize');
         $uploadAttempts = self::getArrayValue($config, 'uploadAttempts');
-        $uploadRetryDelay = self::getArrayValue($config, 'uploadRetryDelay');
+        $uploadRetryDelay = self::getArrayValue($config, 'uploadRetryDelay'); // in milliseconds
 
         if (!$servicesUrl || !$accessKey || !$accessSecret) {
             throw self::error('FCS Client Error: One or all of the following parameters are invalid: ' . 'servicesUrl, accessKey, accessSecret.');
@@ -267,7 +267,7 @@ class Fcs
         }
 
         if (!$uploadRetryDelay) {
-            $uploadRetryDelay = 1000;
+            $uploadRetryDelay = 1000; // 1000 ms, which is 1 second
         }
 
         $this->_baseUri = rtrim($servicesUrl, '/');
@@ -591,7 +591,7 @@ class Fcs
                     if ($this->_uploadAttemptsRemaining <= 0) {
                         throw $e;
                     } else {
-                        sleep($this->_uploadRetryDelay);
+                        usleep($this->_uploadRetryDelay * 1000); // usleep accepts MICRO seconds, but uploadRetryDelay is in MILLI seconds, so convert
                     }
                 }
             }

--- a/src/Fcs/Fcs.php
+++ b/src/Fcs/Fcs.php
@@ -589,7 +589,7 @@ class Fcs
                     // Sending this chunk failed.  If retries remain, wait, then try sending it again.
                     $this->_uploadAttemptsRemaining--;
                     if ($this->_uploadAttemptsRemaining <= 0) {
-                        throw $e;
+                        throw self::error("FCS Send Error: failed to send chunk $chunk of $path after $this->_uploadAttempts attempts");
                     } else {
                         usleep($this->_uploadRetryDelay * 1000); // usleep accepts MICRO seconds, but uploadRetryDelay is in MILLI seconds, so convert
                     }

--- a/src/Fcs/Fcs.php
+++ b/src/Fcs/Fcs.php
@@ -585,7 +585,7 @@ class Fcs
                     $this->sendChunk($uri, $chunkQuery, $path, $contentType, $bytesSent, $chunkSize);
                     $bytesSent += $chunkSize;
                     break; // get out of the while loop
-                } catch (BadResponseException $e) {
+                } catch (ErrorException $e) {
                     // Sending this chunk failed.  If retries remain, wait, then try sending it again.
                     $this->_uploadAttemptsRemaining--;
                     if ($this->_uploadAttemptsRemaining <= 0) {

--- a/src/Fcs/Fcs.php
+++ b/src/Fcs/Fcs.php
@@ -859,7 +859,7 @@ class Fcs
         if (self::isDebugging()) {
             date_default_timezone_set('America/New_York');
             $dt = date('c');
-            $formattedMsg = sprintf('[%s] %s%s', $dt, $msg, self :: NEWLINE);
+            $formattedMsg = sprintf('[%s] %s%s', $dt, $msg, self::NEWLINE);
             if (self::debugFilePath()) {
                 self::writeToFile($formattedMsg);
             }


### PR DESCRIPTION
If you make no change to how `$fcs` is instantiated:

- chunks will be 10 MB
- chunks will be attempts 3 times before failing
- the code will sleep for 1 second

To change these:

```
$fcs = new Fcs(array(
    'url' => 'fcs-services-url',
    'key' => 'your-fcs-access-key',
    'secret' => 'your-fcs-access-secret',
    'chunkSize' => 20971520, // 20 MB 
    'uploadAttempts' => 5,
    'uploadRetryDelay' => 500, // in milliseconds
));
```