### PR TITLE
Add function to transfer an asset from another s3bucket

### DIFF
--- a/src/Fcs/Fcs.php
+++ b/src/Fcs/Fcs.php
@@ -321,7 +321,7 @@ class Fcs
         self::info("FCS Uploading $assetPath");
         $pathInfo = pathinfo($assetPath);
         $ext = strtolower($pathInfo['extension']);
-        $fileName = $pathInfo['basename'];
+
         $contentType = self::$_mimeTypes[$ext];
 
         if ($assetType == null) {
@@ -342,6 +342,11 @@ class Fcs
     public function uploadAsset(array $product, $assetPath, $assetType = null)
     {
         $asset = $this->putAsset($product, $assetPath, $assetType);
+
+        $pathInfo = pathinfo($assetPath);
+        $fileName = $pathInfo['basename'];
+        $ext = strtolower($pathInfo['extension']);
+        $contentType = self::$_mimeTypes[$ext];
 
         $this->sendFile('asset-files/' . $asset['id'], $assetPath, $fileName, $contentType);
 

--- a/src/Fcs/Fcs.php
+++ b/src/Fcs/Fcs.php
@@ -315,7 +315,8 @@ class Fcs
         // https://some-bucket-name.s3.amazonaws.com/path/to/some-asset.epub
         return $this->send('POST', 'copy-s3-asset/' . $assetId . '?s3uri=' . $s3Uri, null, null, false);
     }
-    public function uploadAsset(array $product, $assetPath, $assetType = null)
+
+    public function putAsset(array $product, $assetPath, $assetType = null)
     {
         self::info("FCS Uploading $assetPath");
         $pathInfo = pathinfo($assetPath);
@@ -335,9 +336,23 @@ class Fcs
                        'generated-file-name' => $pathInfo['basename'],
                        'content-type' => $contentType];
 
-        $asset = $this->send('PUT', 'assets', 'asset', $asset);
+        return $this->send('PUT', 'assets', 'asset', $asset);
+    }
+
+    public function uploadAsset(array $product, $assetPath, $assetType = null)
+    {
+        $asset = $this->putAsset($product, $assetPath, $assetType);
 
         $this->sendFile('asset-files/' . $asset['id'], $assetPath, $fileName, $contentType);
+
+        return $asset;
+    }
+
+    public function transferS3Asset(array $product, $s3Uri, $assetType = null)
+    {
+        $asset = $this->putAsset($product, $s3Uri, $assetType);
+
+        $this->postS3AssetPath($asset['id'], $s3Uri);
 
         return $asset;
     }


### PR DESCRIPTION
Github kind of butchered the diff on this.

I added the function transferS3Asset and moved the shared code with uploadAsset to putAsset.  uploadAsset functionality is unchanged.